### PR TITLE
Update NanoESP_MQTT.cpp

### DIFF
--- a/NanoESP_MQTT.cpp
+++ b/NanoESP_MQTT.cpp
@@ -79,6 +79,8 @@ bool NanoESP_MQTT::connect(int id, String broker, unsigned int port, String devi
 
     connectFlag += boolLastWill;
     connectFlag = connectFlag << 1;
+  } else {
+    connectFlag = connectFlag << 4;
   }
 
   connectFlag += cleanSession;


### PR DESCRIPTION
Solves a bug, where publish and subscribe don't work, when user-authentication is on, but no LastWill should be send. Especially when used with:
`bool connect ([s.o], String userName , String password);`
